### PR TITLE
33 remove abn from the installed packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .Rprofile
 renv.lock
 renv/
+*.code-workspace

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -82,7 +82,7 @@ RUN git clone --depth=1 https://$REPO_PATH target
 WORKDIR target/
 # get a list of all dependencies; install remaining packages
 # escape=\
-# Get the package name based on the repository
-RUN PACKAGE_NAME=$(echo $REPO_PATH | grep -oP '(?<=\/)[^\/]+(?=\.git)') # Assumes that the package name equals the repository name.
+# Get the package name based on the repository from the Description file
+RUN PACKAGE_NAME=$(R -s -e "package<-desc::desc(file=file.path('${PACKAGE_PATH}','DESCRIPTION'))\$get_field('Package');writeLines(package)")
 # Install all dependencies of PACKAGE_NAME but not the package it self
-RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs) & !(pckgs == 'PACKAGE_NAME')])"
+RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs) & !(pckgs == '$PACKAGE_NAME')])"

--- a/containers/debian/Dockerfile
+++ b/containers/debian/Dockerfile
@@ -82,4 +82,7 @@ RUN git clone --depth=1 https://$REPO_PATH target
 WORKDIR target/
 # get a list of all dependencies; install remaining packages
 # escape=\
-RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs)])"
+# Get the package name based on the repository
+RUN PACKAGE_NAME=$(echo $REPO_PATH | grep -oP '(?<=\/)[^\/]+(?=\.git)') # Assumes that the package name equals the repository name.
+# Install all dependencies of PACKAGE_NAME but not the package it self
+RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs) & !(pckgs == 'PACKAGE_NAME')])"

--- a/containers/fedora/Dockerfile
+++ b/containers/fedora/Dockerfile
@@ -100,4 +100,7 @@ RUN git clone --depth=1 https://$REPO_PATH target
 WORKDIR target/
 # get a list of all dependencies; install remaining packages
 # escape=\
-RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs)])"
+# Get the package name based on the repository
+RUN PACKAGE_NAME=$(echo $REPO_PATH | grep -oP '(?<=\/)[^\/]+(?=\.git)') # Assumes that the package name equals the repository name.
+# Install all dependencies of PACKAGE_NAME but not the package itself
+RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs) & !(pckgs == 'PACKAGE_NAME')])"

--- a/containers/fedora/Dockerfile
+++ b/containers/fedora/Dockerfile
@@ -100,7 +100,7 @@ RUN git clone --depth=1 https://$REPO_PATH target
 WORKDIR target/
 # get a list of all dependencies; install remaining packages
 # escape=\
-# Get the package name based on the repository
-RUN PACKAGE_NAME=$(echo $REPO_PATH | grep -oP '(?<=\/)[^\/]+(?=\.git)') # Assumes that the package name equals the repository name.
-# Install all dependencies of PACKAGE_NAME but not the package itself
-RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs) & !(pckgs == 'PACKAGE_NAME')])"
+# Get the package name based on the repository from the Description file
+RUN PACKAGE_NAME=$(R -s -e "package<-desc::desc(file=file.path('${PACKAGE_PATH}','DESCRIPTION'))\$get_field('Package');writeLines(package)")
+# Install all dependencies of PACKAGE_NAME but not the package it self
+RUN R -e "renv::deactivate();pckgs<-unique(renv::dependencies('$PACKAGE_PATH')[,'Package']);pres_pckgs<-installed.packages()[,'Package'];install.packages(pckgs[!(pckgs %in% pres_pckgs) & !(pckgs == '$PACKAGE_NAME')])"


### PR DESCRIPTION
Don't install 'abn' in the container, only its dependencies (#33 ). This is redundant since the package will be installed in the workflow that applies this container to ensure that the package version of interest is tested.